### PR TITLE
Add raster image printing

### DIFF
--- a/Emulator/Printables/ReceiptBitmapLine.cs
+++ b/Emulator/Printables/ReceiptBitmapLine.cs
@@ -1,0 +1,35 @@
+﻿using ReceiptPrinterEmulator.Emulator.Abstraction;
+using ReceiptPrinterEmulator.Logging;
+using System;
+using System.Drawing;
+
+namespace ReceiptPrinterEmulator.Emulator.Printables;
+
+public class ReceiptBitmapLine(PaperConfiguration paperConfiguration, Bitmap image) : IReceiptPrintable
+{
+    public int GetPrintHeight()
+    {
+        var printWidth = paperConfiguration.GetPrintWidthInPixels();
+        if (image.Width <= printWidth)
+            return image.Height;
+
+        return (int)Math.Ceiling(image.Height * (float)printWidth / image.Width);
+    }
+
+    public void Render(Bitmap bitmap, Graphics g, int offsetX, int offsetY)
+    {
+        Logger.Info($"Rendering bitmap line at offset ({offsetX}, {offsetY}) with size ({image.Width}, {image.Height})");
+
+        var printWidth = paperConfiguration.GetPrintWidthInPixels();
+        if (image.Width <= printWidth)
+        {
+            // Center the image horizontally if it fits within the print width
+            offsetX += (printWidth - image.Width) / 2;
+            g.DrawImageUnscaled(image, offsetX, offsetY, image.Width, image.Height);
+        }
+        else
+        {
+            g.DrawImage(image, offsetX, offsetY, printWidth, image.Height * (float)printWidth / image.Width);
+        }
+    }
+}

--- a/Emulator/Receipt.cs
+++ b/Emulator/Receipt.cs
@@ -96,6 +96,13 @@ public class Receipt
 
     public void AdvanceToNewLine() => FinalizeTextLine(true);
 
+    public void PrintBitmap(Bitmap image)
+    {
+        FinalizeTextLine(false);
+
+        _renderLines.Add(new ReceiptBitmapLine(_paperConfiguration, image));
+    }
+
     public int GetTotalPrintHeight()
         => _renderLines.Sum(line => line.GetPrintHeight());
 

--- a/Emulator/ReceiptPrinter.cs
+++ b/Emulator/ReceiptPrinter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Text;
 using ReceiptPrinterEmulator.Emulator.Enums;
@@ -196,7 +197,14 @@ public class ReceiptPrinter
 
     public void SetDefaultLineSpacing() => SetLineSpacing(_paperConfiguration.DefaultLineSpacing);
     public void SetDefaultTabSpacing() => SetTabSpacing(_paperConfiguration.DefaultTabSpacing);
-    
+
+    public void PrintBitmap(Bitmap bitmap)
+    {
+        Logger.Info($"Print bitmap: {bitmap.Width}x{bitmap.Height}");
+        
+        CurrentReceipt.PrintBitmap(bitmap);
+    }
+
     #endregion
 
     #region Command API

--- a/EscPos/Commands/GS/PrintRasterBitImageCommand.cs
+++ b/EscPos/Commands/GS/PrintRasterBitImageCommand.cs
@@ -1,0 +1,105 @@
+﻿using ReceiptPrinterEmulator.Emulator;
+using ReceiptPrinterEmulator.Logging;
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Windows.Input;
+
+namespace ReceiptPrinterEmulator.EscPos.Commands.GS;
+
+public class PrintRasterBitImageCommand : BaseCommand
+{
+    public override string Prefix => EscPosInterpreter.GS + "v0";
+    public override bool HasArgs => true;
+
+    private int n = 0;
+    private int m = 0x00;
+    private int xL = 0x00;
+    private int xH = 0x00;
+    private int width = 0;
+    private int yL = 0x00;
+    private int yH = 0x00;
+    private int height = 0;
+    private int length = 0;
+    private byte[]? data = null;
+
+    public override bool InterpretNextChar(char c)
+    {
+        switch (n++)
+        {
+            case 0:
+                m = (int)c;
+                return true;
+            case 1:
+                xL = (int)c;
+                return true;
+            case 2:
+                xH = (int)c;
+                width = (xH << 8) | xL;
+                return true;
+            case 3:
+                yL = (int)c;
+                return true;
+            case 4:
+                yH = (int)c;
+                height = (yH << 8) | yL;
+                length = width * height;
+                width *= 8;
+                data = new byte[length];
+                return length > 0;
+            default:
+                data![n - 6] = (byte)c;
+                return n - 5 < length;
+        }
+    }
+
+    public override void Reset()
+    {
+        n = 0;
+        m = 0x00;
+        xL = 0x00;
+        xH = 0x00;
+        width = 0;
+        yL = 0x00;
+        yH = 0x00;
+        height = 0;
+        length = 0;
+        data = null;
+    }
+
+    public override void Execute(ReceiptPrinter printer, string? args)
+    {
+        var bmp = new Bitmap(width, height, PixelFormat.Format24bppRgb);
+        var values = ReadBytesByBits(length);
+
+        BitmapData bitmapData = bmp.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, bmp.PixelFormat);
+        IntPtr ptr = bitmapData.Scan0;
+        byte value = 0;
+        for (int i = 0; i < values.Length; i++)
+        {
+            value = values[i] == 0 ? (byte)255 : (byte)0;
+            System.Runtime.InteropServices.Marshal.WriteByte(ptr, i * 3 + 0, value);
+            System.Runtime.InteropServices.Marshal.WriteByte(ptr, i * 3 + 1, value);
+            System.Runtime.InteropServices.Marshal.WriteByte(ptr, i * 3 + 2, value);
+        }
+
+        bmp.UnlockBits(bitmapData);
+
+        printer.PrintBitmap(bmp);
+    }
+
+    private byte[] ReadBytesByBits(int size)
+    {
+        byte[] result = new byte[size * 8];
+        byte b;
+        for (int i = 0; i < size; i++)
+        {
+            b = data![i];
+            for (int j = 0; j < 8; j++)
+            {
+                result[i * 8 + j] = (byte)((b >> (7 - j)) & 1);
+            }
+        }
+        return result;
+    }
+}

--- a/EscPos/EscPosInterpreter.cs
+++ b/EscPos/EscPosInterpreter.cs
@@ -68,6 +68,7 @@ public class EscPosInterpreter
         RegisterCommand(new SelectCharacterSizeCommand());
         RegisterCommand(new SelectCutModeAndCutCommand());
         RegisterCommand(new PaperEjectCommand()); // 0x1D, 0x65, n, [m, t]
+        RegisterCommand(new PrintRasterBitImageCommand());
     }
 
     private void RegisterCommand(BaseCommand command)
@@ -128,7 +129,7 @@ public class EscPosInterpreter
                 {
                     var finalArgs = FinalizeCommandBuffer();
 
-                    Logger.Info($"Execute [{_activeCommand.GetType().Name}] with args [{finalArgs}]");
+                    Logger.Info($"Execute [{_activeCommand.GetType().Name}] with args [{(finalArgs.Length > 8 ? $"{finalArgs[..8]}..." : finalArgs)}]");
 
                     _activeCommand.Execute(_printer, finalArgs);
                     _activeCommand = null;

--- a/Networking/NetClient.cs
+++ b/Networking/NetClient.cs
@@ -42,7 +42,7 @@ public class NetClient
     {
         try
         {
-            var receiveBuffer = GC.AllocateArray<byte>(1024, true);
+            var receiveBuffer = GC.AllocateArray<byte>(1024000, true);
             var bufferMemory = receiveBuffer.AsMemory();
 
             while (!_lifetimeCts.Token.IsCancellationRequested)
@@ -68,5 +68,5 @@ public class NetClient
     }
 
     private static void HandleIncomingData(ReadOnlySpan<byte> data) =>
-        App.Printer?.FeedEscPos(Encoding.ASCII.GetString(data));
+        App.Printer?.FeedEscPos(Encoding.Latin1.GetString(data));
 }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
   - Select character size
   - Select cut mode and cut paper
   - Paper eject (`GS e n [m t]`)
+  - Print raster image (`GS v 0 [m xL xH yL yH ...pixels]`)
 
 ### Example
 


### PR DESCRIPTION
This pull request introduces support for printing raster images in the receipt printer emulator, along with some optimizations and adjustments to the networking layer. The most important changes include implementing the `PrintRasterBitImageCommand`, adding bitmap printing functionality to the receipt printer, and increasing the buffer size in the networking layer.

### Bitmap Printing Support:

* [`Emulator/Printables/ReceiptBitmapLine.cs`](diffhunk://#diff-edde3dd9d657c4f81a696bb609913bdaedd94220349d4d65fb7311a3baf318d5R1-R35): Added a new class `ReceiptBitmapLine` to handle rendering bitmap images on receipts. It calculates print height and renders the image with scaling or centering as necessary.
* [`Emulator/Receipt.cs`](diffhunk://#diff-ae17597da0e073f8a0e6a1d76583c866f9045f91e5ad10889f76825bc337a452R99-R105): Introduced the `PrintBitmap` method to add bitmap lines to the receipt.
* [`Emulator/ReceiptPrinter.cs`](diffhunk://#diff-2684591c888de7b2ed7b1505d6eec09ed83827edc82a9b5b79596dca5d527976R201-R207): Added a `PrintBitmap` method to the printer, which logs the bitmap dimensions and delegates rendering to the current receipt.

### ESC/POS Command Enhancements:

* [`EscPos/Commands/GS/PrintRasterBitImageCommand.cs`](diffhunk://#diff-e8223c0daa8504c09fdce964d5fd59c4cd56d3b58cc285a25bb158c950352119R1-R105): Implemented the `PrintRasterBitImageCommand` to interpret and execute the ESC/POS command for printing raster images. It processes image data and sends it to the printer.
* [`EscPos/EscPosInterpreter.cs`](diffhunk://#diff-18d4aaf1aba5c930cc2dfa83e2900ba71a3508a0eeddbb3ea66771f90a257f41R71): Registered the new `PrintRasterBitImageCommand` and improved logging for command execution with truncated arguments. [[1]](diffhunk://#diff-18d4aaf1aba5c930cc2dfa83e2900ba71a3508a0eeddbb3ea66771f90a257f41R71) [[2]](diffhunk://#diff-18d4aaf1aba5c930cc2dfa83e2900ba71a3508a0eeddbb3ea66771f90a257f41L131-R132)

### Networking Optimizations:

* [`Networking/NetClient.cs`](diffhunk://#diff-c940c0e47128e6a151908e778ca5c383fbf76a461c26dd26b443d07f72bdc358L45-R45): Increased the buffer size for receiving data from 1024 bytes to 1,024,000 bytes to accommodate larger payloads, and changed the encoding from ASCII to Latin-1 for better compatibility. [[1]](diffhunk://#diff-c940c0e47128e6a151908e778ca5c383fbf76a461c26dd26b443d07f72bdc358L45-R45) [[2]](diffhunk://#diff-c940c0e47128e6a151908e778ca5c383fbf76a461c26dd26b443d07f72bdc358L71-R71)

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43): Updated the list of supported commands to include the new raster image printing command (`GS v 0`).